### PR TITLE
Implement RV32C compressed instruction set

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ script:
 
     # FIXME: Get a RISC-V toolchain on Travis somehow?
     # - cargo test --verbose
+    # - cargo test --verbose --features="rv32c"
 
     # FIXME: Fails to link tests on Travis, works locally.
     # - |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ exclude = [
 
 [features]
 serialize = ["serde", "serde_derive"]
+rv32c = []
 
 [dependencies]
 serde = { version = "1.0", optional = true }

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Crate](https://img.shields.io/crates/v/rvsim.svg)](https://crates.io/crates/rvsim)
 [![Build Status](https://travis-ci.org/stephank/rvsim.svg?branch=master)](https://travis-ci.org/stephank/rvsim)
 
-A RISC-V simulator implementing RV32G, written in Rust.
+A RISC-V simulator implementing RV32G[C], written in Rust.
 
 See the [documentation] for usage.
 
@@ -14,6 +14,11 @@ See the [documentation] for usage.
 
  - Supports only little-endian hosts.
  - Windows support needs work.
+
+## Features
+
+- `serialize` enable serialization support
+- `rv32c` enable RV32C compressed instruction set support
 
 ## License
 

--- a/build/cpu.rs
+++ b/build/cpu.rs
@@ -11,7 +11,8 @@ use std::rc::Rc;
 struct Variant {
     name: String,
     method: String,
-    args: Vec<(String, String)>,
+    // name, extract, typ
+    args: Vec<(String, String, String)>,
 }
 
 struct ParseNode {
@@ -24,12 +25,52 @@ enum ParseAction {
     Descend(ParseNode),
 }
 
+/** Build the parse tree. */
+fn build_parse_tree(parse_tree: &mut ParseNode, matchers: &Vec<(&str, &str)>, first_field: &str, variant: Rc<Variant>) {
+    let mut node = parse_tree;
+    let mut prev_value = {
+        let (field, value) = matchers[0];
+        assert_eq!(field, first_field, "parser must start with {} field", first_field);
+        value.to_owned()
+    };
+    for &(next_field, next_value) in &matchers[1..] {
+        let prev_node = node;
+        match prev_node.actions.entry(prev_value).or_insert_with(|| {
+            ParseAction::Descend(ParseNode {
+                field: next_field.to_owned(),
+                actions: HashMap::new(),
+            })
+        }) {
+            &mut ParseAction::Descend(ref mut next_node) => {
+                assert_eq!(next_node.field, next_field, "parser field order must match");
+                node = next_node;
+            },
+            &mut ParseAction::Finish(_) => {
+                panic!("parser tried to descend into existing match");
+            },
+        }
+        prev_value = next_value.to_owned();
+    }
+    match node.actions.entry(prev_value) {
+        Entry::Vacant(entry) => {
+            entry.insert(ParseAction::Finish(variant));
+        },
+        Entry::Occupied(_) => {
+            panic!("conflicting field value in parser");
+        },
+    }
+}
+
 pub fn build() {
     println!("# generating cpu code");
 
     let mut variants = vec![];
     let mut parse_tree = ParseNode {
         field: "opcode".to_owned(),
+        actions: HashMap::new(),
+    };
+    let mut parse_tree_c = ParseNode {
+        field: "cquad".to_owned(),
         actions: HashMap::new(),
     };
 
@@ -49,7 +90,7 @@ pub fn build() {
             // Extract the method name and argument names.
             let method = line[3..].splitn(2, '(').next().unwrap().to_owned();
             let args = args_re.captures_iter(&line)
-                .map(|c| (c[1].to_owned(), c[2].to_owned()))
+                .map(|c| (c[1].to_owned(), c[1].to_owned(), c[2].to_owned()))
                 .collect::<Vec<_>>();
 
             // Camelcase the method name to create the `Op` enum variant.
@@ -69,39 +110,39 @@ pub fn build() {
                 (field, value)
             }).collect::<Vec<_>>();
 
-            // Build the parse tree.
-            let mut node = &mut parse_tree;
-            let mut prev_value = {
-                let (field, value) = matchers[0];
-                assert_eq!(field, "opcode", "parser must start with opcode field");
-                value.to_owned()
-            };
-            for &(next_field, next_value) in &matchers[1..] {
-                let prev_node = node;
-                match prev_node.actions.entry(prev_value).or_insert_with(|| {
-                    ParseAction::Descend(ParseNode {
-                        field: next_field.to_owned(),
-                        actions: HashMap::new(),
-                    })
-                }) {
-                    &mut ParseAction::Descend(ref mut next_node) => {
-                        assert_eq!(next_node.field, next_field, "parser field order must match");
-                        node = next_node;
-                    },
-                    &mut ParseAction::Finish(_) => {
-                        panic!("parser tried to descend into existing match");
-                    },
-                }
-                prev_value = next_value.to_owned();
-            }
-            match node.actions.entry(prev_value) {
-                Entry::Vacant(entry) => {
-                    entry.insert(ParseAction::Finish(variant));
-                },
-                Entry::Occupied(_) => {
-                    panic!("conflicting field value in parser");
-                },
-            }
+            build_parse_tree(&mut parse_tree, &matchers, "opcode", variant);
+        }
+
+        // Parsing for decompression
+        if prev.starts_with("//% ") && line.starts_with("//    ") {
+            // Parse the matchers in the comment.
+            let matchers = prev[4..].split_whitespace().map(|s| {
+                let mut split = s.splitn(2, '=');
+                let field = split.next().unwrap();
+                let value = split.next().unwrap();
+                (field, value)
+            }).collect::<Vec<_>>();
+
+            // Parse the metadata in the comment.
+            let meta = line[6..].split_whitespace().map(|s| {
+                let mut split = s.splitn(2, '=');
+                let field = split.next().unwrap();
+                let value = split.next().unwrap();
+                (field, value)
+            }).collect::<Vec<_>>();
+
+            assert_eq!(meta[0].0, "name", "rv32c description must start with instruction name");
+            assert_eq!(meta[1].0, "decomp", "second part of rv32c description must be decompressed instruction name");
+
+            // Camelcase the method name to create the `Op` enum variant.
+            let name = meta[1].1.split('_').map(|s| {
+                format!("{}{}", s[..1].to_uppercase(), &s[1..])
+            }).collect::<Vec<_>>().join("");
+
+            let args = meta[2..].iter().map(|(a,b)| { ( a.to_string(), b.to_string(), String::new() ) }).collect::<Vec<_>>();
+            let variant = Rc::new(Variant { name, method:meta[1].1.to_string(), args });
+
+            build_parse_tree(&mut parse_tree_c, &matchers, "cquad", variant);
         }
 
         prev = line;
@@ -114,7 +155,7 @@ pub fn build() {
         if args.is_empty() {
             writeln!(variants_src, "    {},", name).unwrap();
         } else {
-            let field_src = args.iter().map(|&(ref name, ref typ)| {
+            let field_src = args.iter().map(|&(ref name, _, ref typ)| {
                 format!("{}: {}", name, typ)
             }).collect::<Vec<_>>().join(", ");
             writeln!(variants_src, "    {} {{ {} }},", name, field_src).unwrap();
@@ -125,34 +166,52 @@ pub fn build() {
     fn node_parse_src(node: &ParseNode, indent: usize) -> String {
         let spaces = " ".repeat(indent);
         let mut src = format!("{}match {}(instr) {{\n", spaces, node.field);
-        for (value, action) in &node.actions {
-            src.push_str(&format!("{}    0b{} => {{\n", spaces, value));
+        let mut have_default = false;
+        let mut items = node.actions.iter().collect::<Vec<_>>();
+        items.sort_by_key(|(k,_)| {*k});
+
+        for (value, action) in items {
+            if value == "_" {
+                src.push_str(&format!("{}    _ => {{\n", spaces));
+                have_default = true;
+            } else {
+                src.push_str(&format!("{}    0b{} => {{\n", spaces, value));
+            }
             match action {
                 &ParseAction::Descend(ref child) => {
                     src.push_str(&node_parse_src(child, indent + 8));
                 },
                 &ParseAction::Finish(ref variant) => {
-                    src.push_str(&format!("{}        Some(Op::{} {{\n", spaces, variant.name));
-                    for &(ref name, _) in &variant.args {
-                        src.push_str(&format!("{}            {}: {}(instr),\n", spaces, name, name));
+                    if variant.method == "illegal" {
+                        src.push_str(&format!("{}        None\n", spaces));
+                    } else {
+                        src.push_str(&format!("{}        Some(Op::{} {{\n", spaces, variant.name));
+                        for &(ref name, ref extract, _) in &variant.args {
+                            src.push_str(&format!("{}            {}: {}(instr),\n", spaces, name, extract));
+                        }
+                        src.push_str(&format!("{}        }})\n", spaces));
                     }
-                    src.push_str(&format!("{}        }})\n", spaces));
                 },
             }
             src.push_str(&format!("{}    }},\n", spaces));
         }
-        src.push_str(&format!("{}    _ => None,\n", spaces));
+        if !have_default {
+            src.push_str(&format!("{}    _ => None,\n", spaces));
+        }
         src.push_str(&format!("{}}}\n", spaces));
         src
     }
     let parse_src = node_parse_src(&parse_tree, 8);
+
+    // Generate `Op::parse_c` source code.
+    let parse_c_src = node_parse_src(&parse_tree_c, 8);
 
     // Generate `Interp` dispatch source code.
     let mut dispatch_src = String::new();
     let spaces = " ".repeat(12);
     for variant in &variants {
         let &Variant { ref name, ref method, ref args } = &**variant;
-        let params = args.iter().map(|&(ref name, _)| name.as_str())
+        let params = args.iter().map(|&(ref name, _, _)| name.as_str())
             .collect::<Vec<_>>().join(", ");
         let pattern = if params.is_empty() {
             "".to_owned()
@@ -171,6 +230,7 @@ pub fn build() {
         match line.trim() {
             "//% variants" => file.write_all(variants_src.as_bytes()),
             "//% parse" => file.write_all(parse_src.as_bytes()),
+            "//% parse_c" => file.write_all(parse_c_src.as_bytes()),
             _ => writeln!(file, "{}", line),
         }.unwrap();
     }

--- a/src/cpu/op.in.rs
+++ b/src/cpu/op.in.rs
@@ -10,6 +10,12 @@ impl Op {
     pub fn parse(instr: u32) -> Option<Op> {
         //% parse
     }
+
+    /// Parse a rv32c instruction. Returns `None` on failure.
+    #[cfg(feature = "rv32c")]
+    pub fn parse_c(instr: u16) -> Option<Op> {
+        //% parse_c
+    }
 }
 
 //
@@ -134,3 +140,146 @@ fn zimm(instr: u32) -> u32 {
 fn unused1(instr: u32) -> u32 {
     (instr & 0b1111_0000_0000_0000_0000_0000_0000_0000) >> 23
 }
+
+//
+// RV32C fields.
+//
+#[cfg(feature = "rv32c")]
+mod rv32c {
+    // Opcode selectors.
+    pub fn cquad(instr: u16) -> u16 {
+        (instr & 0b0000_0000_0000_0011)
+    }
+    pub fn cfunct3(instr: u16) -> u16 {
+        (instr & 0b1110_0000_0000_0000) >> 13
+    }
+    pub fn cfunct4_l0(instr: u16) -> u16 {
+        (instr & 0b0001_0000_0000_0000) >> 12
+    }
+    pub fn crs1rd_h2(instr: u16) -> u16 {
+        (instr & 0b0000_1100_0000_0000) >> 10
+    }
+    pub fn crs2_h2(instr: u16) -> u16 {
+        (instr & 0b0000_0000_0110_0000) >> 5
+    }
+
+    // Hardwired register fields.
+    pub fn crx0(_instr: u16) -> usize {
+        0
+    }
+
+    pub fn crra(_instr: u16) -> usize {
+        1
+    }
+
+    pub fn crsp(_instr: u16) -> usize {
+        2
+    }
+
+    // Registers x0..x31.
+    pub fn crs1rd(instr: u16) -> usize {
+        ((instr & 0b0000_1111_1000_0000) as usize) >> 7
+    }
+    pub fn crs2(instr: u16) -> usize {
+        ((instr & 0b0000_0000_0111_1100) as usize) >> 2
+    }
+
+    // Registers x8..x15.
+    pub fn crs1rdq(instr: u16) -> usize {
+        (((instr & 0b0000_0011_1000_0000) as usize) >> 7) + 8
+    }
+    pub fn crs2q(instr: u16) -> usize {
+        (((instr & 0b0000_0000_0001_1100) as usize) >> 2) + 8
+    }
+
+    // Hardwired immediates.
+    pub fn czero(_instr: u16) -> i32 {
+        0
+    }
+
+    // Immediates (zero-extended).
+    pub fn cimmsh6(instr: u16) -> u32 {
+        (((instr & 0b0001_0000_0000_0000) as u32) >> 12) << 5 |
+        (((instr & 0b0000_0000_0111_1100) as u32) >> 2)
+    }
+
+    pub fn cimmlwsp(instr: u16) -> i32 {
+        (((instr & 0b0001_0000_0000_0000) >> 12) << 5 |
+         ((instr & 0b0000_0000_0111_0000) >> 4) << 2 |
+         ((instr & 0b0000_0000_0000_1100) >> 2) << 6) as i32
+    }
+
+    pub fn cimmldsp(instr: u16) -> i32 {
+        (((instr & 0b0001_0000_0000_0000) >> 12) << 5 |
+         ((instr & 0b0000_0000_0110_0000) >> 5) << 3 |
+         ((instr & 0b0000_0000_0001_1100) >> 2) << 6) as i32
+    }
+
+    pub fn cimmswsp(instr: u16) -> i32 {
+        (((instr & 0b0001_1110_0000_0000) >> 9) << 2 |
+         ((instr & 0b0000_0001_1000_0000) >> 7) << 6) as i32
+    }
+
+    pub fn cimmsdsp(instr: u16) -> i32 {
+        (((instr & 0b0001_1100_0000_0000) >> 10) << 3 |
+         ((instr & 0b0000_0011_1000_0000) >> 7) << 6) as i32
+    }
+
+    pub fn cimm4spn(instr: u16) -> i32 {
+        (((instr & 0b0001_1000_0000_0000) >> 11) << 4 |
+         ((instr & 0b0000_0111_1000_0000) >> 7) << 6 |
+         ((instr & 0b0000_0000_0100_0000) >> 6) << 2 |
+         ((instr & 0b0000_0000_0010_0000) >> 5) << 3) as i32
+    }
+
+    pub fn cimmw(instr: u16) -> i32 {
+        (((instr & 0b0001_1100_0000_0000) >> 10) << 3 |
+         ((instr & 0b0000_0000_0100_0000) >> 6) << 2 |
+         ((instr & 0b0000_0000_0010_0000) >> 5) << 6) as i32
+    }
+
+    pub fn cimmd(instr: u16) -> i32 {
+        (((instr & 0b0001_1100_0000_0000) >> 10) << 3 |
+         ((instr & 0b0000_0000_0110_0000) >> 5) << 6) as i32
+    }
+
+    // Immediates (sign-extended).
+    pub fn cimmi(instr: u16) -> i32 {
+        (((instr & 0b0001_0000_0000_0000) as i32) << (31-12)) >> (31-5) |
+        (((instr & 0b0000_0000_0111_1100) as i32) >> 2)
+    }
+
+    pub fn cimmui(instr: u16) -> i32 {
+        (((instr & 0b0001_0000_0000_0000) as i32) << (31-12)) >> (31-17) |
+        (((instr & 0b0000_0000_0111_1100) as i32) >> 2) << 12
+    }
+
+    pub fn cimm16sp(instr: u16) -> i32 {
+        (((instr & 0b0001_0000_0000_0000) as i32) << (31-12)) >> (31-9) |
+        (((instr & 0b0000_0000_0100_0000) as i32) >> 6) << 4 |
+        (((instr & 0b0000_0000_0010_0000) as i32) >> 5) << 6 |
+        (((instr & 0b0000_0000_0001_1000) as i32) >> 3) << 7 |
+        (((instr & 0b0000_0000_0000_0100) as i32) >> 2) << 5
+    }
+
+    pub fn cimmj(instr: u16) -> i32 {
+        (((instr & 0b0001_0000_0000_0000) as i32) << (31-12)) >> (31-11) |
+        (((instr & 0b0000_1000_0000_0000) as i32) >> 11) << 4 |
+        (((instr & 0b0000_0110_0000_0000) as i32) >> 9) << 8 |
+        (((instr & 0b0000_0001_0000_0000) as i32) >> 8) << 10 |
+        (((instr & 0b0000_0000_1000_0000) as i32) >> 7) << 6 |
+        (((instr & 0b0000_0000_0100_0000) as i32) >> 6) << 7 |
+        (((instr & 0b0000_0000_0011_1000) as i32) >> 3) << 1 |
+        (((instr & 0b0000_0000_0000_0100) as i32) >> 2) << 5
+    }
+
+    pub fn cimmb(instr: u16) -> i32 {
+        (((instr & 0b0001_0000_0000_0000) as i32) << (31-12)) >> (31-8) |
+        (((instr & 0b0000_1100_0000_0000) as i32) >> 10) << 3 |
+        (((instr & 0b0000_0000_0110_0000) as i32) >> 5) << 6 |
+        (((instr & 0b0000_0000_0001_1000) as i32) >> 3) << 1 |
+        (((instr & 0b0000_0000_0000_0100) as i32) >> 2) << 5
+    }
+}
+#[cfg(feature = "rv32c")]
+use self::rv32c::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 #![warn(missing_docs)]
 #![cfg_attr(feature = "cargo-clippy", allow(doc_markdown))]
 
-//! A RISC-V simulator implementing RV32G.
+//! A RISC-V simulator implementing RV32G[C].
 //!
 //! ## Usage
 //!

--- a/tests/env/meta.rs
+++ b/tests/env/meta.rs
@@ -1,4 +1,7 @@
 const ISA_TESTS: &[(&str, &str)] = &[
+    #[cfg(feature = "rv32c")]
+    ("rv32uc", "rvc"),
+
     ("rv32ui", "add"),
     ("rv32ui", "addi"),
     ("rv32ui", "and"),


### PR DESCRIPTION
This extends the simulator to add support for the RV32C compressed instructions extension. This extension does not add any instructions, but provides shorter aliases for some 32-bit instructions. It also makes 4-byte instructions starting on 2-byte boundaries valid.

Analogous to the existing code, the RV32C instruction parsing code is generated from a table in `interp.in.rs`. This required a few small changes in `build/cpu.rs`.

Extractors are added for the various fields specific to 16-bit instruction encoding.

`rv32uc` is added to the ISA tests to test the decoding and emulation code.

Gate the functionality behind a crate feature `rv32c`.