### PR TITLE
Make the SimpleClock count instructions

### DIFF
--- a/src/cpu/types.rs
+++ b/src/cpu/types.rs
@@ -154,7 +154,7 @@ pub trait Clock {
     ///
     /// Note that, even though these values are 64-bit, it is recommended implementations use
     /// `wrapping_add`.
-    fn progress(&self, op: &Op);
+    fn progress(&mut self, op: &Op);
 
     /// Check execution quotas. Called at the very start of `Interp::step`.
     ///
@@ -198,7 +198,7 @@ impl Clock for SimpleClock {
         self.instret
     }
 
-    fn progress(&self, _op: &Op) {
-        self.instret.wrapping_add(1);
+    fn progress(&mut self, _op: &Op) {
+        self.instret = self.instret.wrapping_add(1);
     }
 }


### PR DESCRIPTION
The `progress()` function was not updating the clock because the result of the wrapping add was ignored, fix this.