### PR TITLE
Upgrade to cc crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ serde_derive = { version = "1.0", optional = true }
 rayon = "1.0"
 
 [build-dependencies]
-gcc = "0.3"
+cc = "1.0"
 regex = "0.2"
 
 [package.metadata.docs.rs]

--- a/build/main.rs
+++ b/build/main.rs
@@ -1,4 +1,4 @@
-extern crate gcc;
+extern crate cc;
 extern crate regex;
 
 mod cpu;

--- a/build/softfloat.rs
+++ b/build/softfloat.rs
@@ -1,4 +1,4 @@
-use gcc::Build;
+use cc::Build;
 
 const SOURCE_DIR: &str = "vendor/SoftFloat-3e/source";
 


### PR DESCRIPTION
The `gcc` crate is deprecated in favour of `cc`.