### PR TITLE
Run tests and clippy on Travis, fix linker errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: xenial
+language: minimal
 sudo: required
 services:
   - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,32 +1,48 @@
-sudo: false
-language: rust
-env:
-  - CC=clang
+sudo: required
+services:
+  - docker
 
-matrix:
-    include:
-        - rust: stable
-        - rust: beta
-        - rust: nightly
-    allow_failures:
-        - rust: beta
-        - rust: nightly
-    fast_finish: true
+# Travis mysteriously parses an indent in this install script, but not in the
+# build script below. So we account for it in the heredoc terminator.
+install:
+  - |
+    docker build \
+      --pull \
+      -t travis.test/env \
+      - << '  EOF'
+    FROM ubuntu:18.04
+
+    RUN set -x \
+      && apt-get update \
+      && apt-get install -y \
+        build-essential \
+        curl \
+        gcc-8-riscv64-linux-gnu \
+      && rm -rf /var/lib/apt/lists/*
+
+    RUN useradd -m build
+    USER build
+    WORKDIR /home/build
+
+    RUN set -x \
+      && curl https://sh.rustup.rs -sSf | sh -s -- -y \
+      && .cargo/bin/rustup component add clippy-preview
+    EOF
 
 script:
-    - cargo build --verbose
-    - cargo build --verbose --features="rv32c"
-    - cargo build --verbose --no-default-features
-    - cargo build --verbose --no-default-features --features="rv32c"
-
-    # FIXME: Get a RISC-V toolchain on Travis somehow?
-    # - cargo test --verbose
-    # - cargo test --verbose --features="rv32c"
-    # - cargo test --verbose --no-default-features
-    # - cargo test --verbose --no-default-features --features="rv32c"
-
-    # FIXME: Fails to link tests on Travis, works locally.
-    # - |
-    #     if [ $TRAVIS_RUST_VERSION == "nightly" ]; then
-    #         cargo install clippy && cargo clippy -- -Dclippy
-    #     fi
+  - |
+    docker run \
+      --rm \
+      -i \
+      -v $PWD:/src \
+      travis.test/env \
+      bash -xe << 'EOF'
+    source /home/build/.cargo/env
+    cp -r /src src
+    cd src/
+    cargo clippy --all-features
+    cargo test --verbose
+    cargo test --verbose --features="rv32c"
+    cargo test --verbose --no-default-features
+    cargo test --verbose --no-default-features --features="rv32c"
+    EOF

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ rayon = "1.0"
 
 [build-dependencies]
 cc = "1.0"
-regex = "0.2"
+regex = "1.0"
 
 [package.metadata.docs.rs]
 all-features = true 

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -185,7 +185,7 @@ impl<'a> Elf32<'a> {
         }
 
         let header: &'a ElfHeader32 = unsafe {
-            transmute(data.as_ptr().offset(size_of::<ElfIdent>() as isize))
+            transmute(data.as_ptr().add(size_of::<ElfIdent>()))
         };
         if header.version != ELF_VERSION_CURRENT {
             let header_version = header.version;

--- a/src/softfloat.rs
+++ b/src/softfloat.rs
@@ -125,27 +125,27 @@ impl From<Sf64> for f32 {
 
 extern "C" {
     /// Get the exception flags from thread-local storage.
-    #[link_name = "\u{1}_softfloat_getFlags"]
+    #[link_name = "softfloat_getFlags"]
     pub fn get_flags() -> u8;
     /// Set the exception flags.
-    #[link_name = "\u{1}_softfloat_setFlags"]
+    #[link_name = "softfloat_setFlags"]
     pub fn set_flags(arg1: u8);
     /// Add to the exception flags.
-    #[link_name = "\u{1}_softfloat_raiseFlags"]
+    #[link_name = "softfloat_raiseFlags"]
     pub fn raise_flags(arg1: u8);
 
     /// Get the current rounding mode from thread-local storage.
-    #[link_name = "\u{1}_softfloat_getRoundingMode"]
+    #[link_name = "softfloat_getRoundingMode"]
     pub fn get_rounding_mode() -> u8;
     /// Set the rounding mode.
-    #[link_name = "\u{1}_softfloat_setRoundingMode"]
+    #[link_name = "softfloat_setRoundingMode"]
     pub fn set_rounding_mode(arg1: u8);
 
     /// Convert a `u32` to a single-precision value.
-    #[link_name = "\u{1}_ui32_to_f32"]
+    #[link_name = "ui32_to_f32"]
     pub fn u32_to_f32(arg1: u32) -> Sf32;
     /// Convert a `u32` to a double-precision value.
-    #[link_name = "\u{1}_ui32_to_f64"]
+    #[link_name = "ui32_to_f64"]
     pub fn u32_to_f64(arg1: u32) -> Sf64;
     /// Convert an `i32` to a single-precision value.
     pub fn i32_to_f32(arg1: i32) -> Sf32;
@@ -153,7 +153,7 @@ extern "C" {
     pub fn i32_to_f64(arg1: i32) -> Sf64;
 
     /// Convert a single-precision value to a `u32`.
-    #[link_name = "\u{1}_f32_to_ui32"]
+    #[link_name = "f32_to_ui32"]
     pub fn f32_to_u32(arg1: Sf32, arg2: u8, arg3: bool) -> u32;
     /// Convert a single-precision value to an `i32`.
     pub fn f32_to_i32(arg1: Sf32, arg2: u8, arg3: bool) -> i32;
@@ -180,11 +180,11 @@ extern "C" {
     /// Test less-than with single-precision values.
     pub fn f32_lt(arg1: Sf32, arg2: Sf32) -> bool;
     /// Whether the single-precision value is a signalling NaN.
-    #[link_name = "\u{1}_f32_isSignalingNaN"]
+    #[link_name = "f32_isSignalingNaN"]
     pub fn f32_is_signaling_nan(arg1: Sf32) -> bool;
 
     /// Convert a double-precision value to a `u32`.
-    #[link_name = "\u{1}_f64_to_ui32"]
+    #[link_name = "f64_to_ui32"]
     pub fn f64_to_u32(arg1: Sf64, arg2: u8, arg3: bool) -> u32;
     /// Convert a double-precision value to an `i32`.
     pub fn f64_to_i32(arg1: Sf64, arg2: u8, arg3: bool) -> i32;
@@ -211,6 +211,6 @@ extern "C" {
     /// Test less-than with double-precision values.
     pub fn f64_lt(arg1: Sf64, arg2: Sf64) -> bool;
     /// Whether the double-precision value is a signalling NaN.
-    #[link_name = "\u{1}_f64_isSignalingNaN"]
+    #[link_name = "f64_isSignalingNaN"]
     pub fn f64_is_signaling_nan(arg1: Sf64) -> bool;
 }

--- a/tests/cpu.rs
+++ b/tests/cpu.rs
@@ -51,10 +51,11 @@ fn build_riscv_tests() {
         }
 
         let in_file = format!("{}/{}.S", set, name);
-        let mut cmd = Command::new("riscv64-unknown-elf-gcc");
+        let mut cmd = Command::new("riscv64-linux-gnu-gcc-8");
         cmd.args(&[
             "-march=rv32g",
             "-mabi=ilp32",
+            "-nostdlib",
             "-nostartfiles",
             "-I./../../../tests/env",
             "-I./macros/scalar",


### PR DESCRIPTION
Fixes #1. The `\u{1}` in `link_name` apparently tells LLVM to not mangle the symbol name. For macOS, that `_` prefix apparently comes from mangling. I think just removing the whole flag and prefix means LLVM does mangling for both C and the Rust bindings, which should work fine everywhere. Tested on macOS and Ubuntu.

Fixes #7. We no longer test on beta and nightly, but can run tests and clippy now. I think those are more important. :)