### PR TITLE
Silence "unnecessary parentheses" warnings in generated code

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,6 +96,7 @@
 #[macro_use]
 extern crate serde_derive;
 
+#[allow(unused_parens)]
 mod cpu;
 
 pub mod elf;


### PR DESCRIPTION
When compiling with recent rust compilers there are a few warnings like:
```
warning: unnecessary parentheses around block return value
    --> /…/target/release/build/rvsim-032eecd380573c6b/out/op.rs:1062:9
     |
1062 |         (instr & 0b0000_0000_0000_0011)
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove these parenthese
```
These are kind of noisy and unnecessary themselves, so disable them.