### PR TITLE
Fix jalr semantics.

### DIFF
--- a/src/cpu/interp.in.rs
+++ b/src/cpu/interp.in.rs
@@ -256,11 +256,12 @@ impl<'s, 'm, 'c, M: 'm + Memory, C: 'c + Clock> Interp<'s, 'm, 'c, M, C> {
 
     //% opcode=110_0111 funct3=000
     fn jalr(&mut self, rd: usize, rs1: usize, i_imm: i32) -> CpuExit {
+        let dst_base = self.state.x[rs1];
         write_rd!(self, rd, {
             self.state.pc.wrapping_add(self.instsz)
         });
         end_jump_op!(self, {
-            self.state.x[rs1].wrapping_add(i_imm as u32)
+            dst_base.wrapping_add(i_imm as u32)
         })
     }
 


### PR DESCRIPTION
When `rd == rs1` the `jalr` instruction sets PC to the newly-written value, but the previous value should be used.

Example:

```
       8:	00019097          	auipc	ra,0x19
       c:	f60080e7          	jalr	-160(ra) # 18f68 <main>
```